### PR TITLE
Remove double html: entry

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -6,16 +6,15 @@ author: Wageningen
 
 html:
   baseurl: "/Course-material-Catchment-and-Climate-hydrology"
+# START DRAFT
+  comments:
+    hypothesis: true
+# END DRAFT
 
 # Execute notebooks when building
 execute:
   execute_notebooks: auto
 
-# START DRAFT
-html:
-  comments:
-    hypothesis: true
-# END DRAFT
 html_static_path:
     - lec_slides
     


### PR DESCRIPTION
The draft fences are ignored by the [teachbook recombiner](https://teachbooks.io/recombiner/), and the double `html:` entry breaks the parser.

This change will still leave the draft comment things in place (see https://teachbooks.io/manual/features/draft-release.html) while removing the duplicate yaml entry.